### PR TITLE
rk3399: allocate more space for kernel image

### DIFF
--- a/include/configs/rk3399_common.h
+++ b/include/configs/rk3399_common.h
@@ -39,8 +39,8 @@
 	"fdt_addr_r=0x01f00000\0" \
 	"fdtoverlay_addr_r=0x02000000\0" \
 	"kernel_addr_r=0x02080000\0" \
-	"ramdisk_addr_r=0x06000000\0" \
-	"kernel_comp_addr_r=0x08000000\0" \
+	"ramdisk_addr_r=0x08000000\0" \
+	"kernel_comp_addr_r=0x0a000000\0" \
 	"kernel_comp_size=0x2000000\0"
 
 #ifndef ROCKCHIP_DEVICE_SETTINGS


### PR DESCRIPTION
Linux 6.7 compiled without compression with the AArch64 defconfig is too large to fit into the 64MiB usable kernel space with an initrd. Add an additional 32MiB to prevent image space errors.